### PR TITLE
Upadate to 0.2.1: support different behaviours in query and document tokenization

### DIFF
--- a/examples/tct-colbert/modeling_tct.py
+++ b/examples/tct-colbert/modeling_tct.py
@@ -1,0 +1,78 @@
+import os
+import torch
+from typing import List, Tuple
+
+from torch import nn
+from transformers import BertConfig, BertModel, BertPreTrainedModel, BertTokenizerFast, AutoTokenizer
+
+from repconc.models.repconc import RepCONC
+
+class TCTEncoder(BertPreTrainedModel):
+    def __init__(self, config: BertConfig):
+        BertPreTrainedModel.__init__(self, config)
+        self.bert = BertModel(config, add_pooling_layer=False)
+        self.config.pooling = "mean"
+        self.config.similarity_metric = "METRIC_IP"
+    
+    def forward(self, input_ids, attention_mask, return_dict=False):
+        outputs = self.bert(input_ids, attention_mask, return_dict=True)
+        token_embeds = outputs.last_hidden_state[:, 4:, :]
+        input_mask_expanded = attention_mask[:, 4:].unsqueeze(-1).expand(token_embeds.size()).float()
+        text_embeds = torch.sum(token_embeds * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+        if return_dict:
+            outputs.embedding = text_embeds
+            return outputs
+        else:
+            return text_embeds
+
+    @property
+    def language_model(self):
+        return self.bert
+
+
+def tct_repconc_from_pretrained(load_dir, use_constraint, sk_epsilon, sk_iters):
+    dense_encoder = TCTEncoder.from_pretrained(os.path.join(load_dir, 'dense_encoder'))
+    repconc = RepCONC(
+        dense_encoder.config, 
+        dense_encoder, 
+        use_constraint=use_constraint, 
+        sk_epsilon=sk_epsilon, 
+        sk_iters=sk_iters)
+    repconc.load_state_dict(torch.load(os.path.join(load_dir, "pytorch_model.bin"), map_location="cpu"))
+    return repconc
+
+
+class TCTTokenizerFast(BertTokenizerFast):
+    '''
+    ANCE lowers text before tokenization
+    '''
+    def __call__(self, text, input_text_type, max_length=None, add_special_tokens=False, **kwargs):
+        # TCT does not add special tokens and expands queries to a fixed length
+        if input_text_type == "query":
+            max_length = 36
+            text = ['[CLS] [Q] ' + query + '[MASK]' * 36 for query in text ]
+        elif input_text_type == "doc":
+            text = ['[CLS] [D] ' + doc for doc in text ]
+        else:
+            raise NotImplementedError()
+        return super().__call__(text, max_length=max_length, add_special_tokens=False, **kwargs)
+
+
+if __name__ == "__main__":
+    print(AutoTokenizer.from_pretrained("castorini/tct_colbert-v2-hnp-msmarco"))
+    print("Test tokenizer")
+    import inspect
+
+    for tokenizer_class in [AutoTokenizer, TCTTokenizerFast]:
+        tokenizer = tokenizer_class.from_pretrained("castorini/tct_colbert-v2-hnp-msmarco")
+        print(tokenizer.__class__, tokenizer)
+        text_lst = ["I am TCT tokenizer"]
+
+        input_text_type = {"input_text_type": "doc"} if "input_text_type" in inspect.getfullargspec(tokenizer.__call__)[0] else {}
+        print(tokenizer.convert_ids_to_tokens(tokenizer(
+            text_lst, 
+            add_special_tokens=True, 
+            max_length=36, 
+            truncation=True, **input_text_type)['input_ids'][0]))
+        input_text_type = {"input_text_type": "query"} if "input_text_type" in inspect.getfullargspec(tokenizer.__call__)[0] else {}
+        print(tokenizer.convert_ids_to_tokens(tokenizer(text_lst, add_special_tokens=True, max_length=36, truncation=True, **input_text_type)['input_ids'][0]))

--- a/examples/tct-colbert/msmarco-passage/3_encode_dense_corpus.sh
+++ b/examples/tct-colbert/msmarco-passage/3_encode_dense_corpus.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+echo "Evaluate the customized dense retrieval model, so that: "
+echo "- we can know whether we sucessfully reproduce the retrieval results."
+echo "- Reused to sample a small validation set. Otherwise, the original corpus is to large to efficiently validate model effectiveness during training."
+echo "- For RepCONC, the corpus encodings will be reused for warmup centroids and generating hard negatives."
+echo "- For JPQ, the corpus encodings will be reused for warmup centroids and training and inference."
+
+echo "Pass the gpu counts (default: 1)"
+
+gpus=${1:-1}
+
+root="../../data/tct-colbert-v2-marco-passage"
+dataset_dir="${root}/dataset"
+model_path="castorini/tct_colbert-v2-hnp-msmarco"
+output_dir="${root}/dense_output"
+
+corpus_path="${dataset_dir}/corpus.tsv"
+
+mkdir -p $output_dir
+out_corpus_dir="${output_dir}/corpus"
+
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+for mode in "trec19" "trec20" "dev" 
+do
+    timestamp=`date "+%m-%d-%H:%M"`
+    log_path="${output_dir}/${timestamp}.log"
+    echo log_path: $log_path
+
+    python $distributed_cmd \
+        run_tct_dense_eval.py \
+        --corpus_path $corpus_path \
+        --query_path "${dataset_dir}/query.${mode}" \
+        --output_dir $output_dir \
+        --out_corpus_dir $out_corpus_dir \
+        --out_query_dir "${output_dir}/${mode}" \
+        --qrel_path "${dataset_dir}/qrels.${mode}" \
+        --model_name_or_path $model_path \
+        --per_device_eval_batch_size 64 \
+        --dataloader_num_workers 4 \
+        --save_corpus_embed \
+        --save_query_embed \
+        |& tee $log_path   
+done

--- a/examples/tct-colbert/msmarco-passage/4_gen_valid_set.sh
+++ b/examples/tct-colbert/msmarco-passage/4_gen_valid_set.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+echo "We will sample a small corpus to efficiently validate model effectiveness during training"
+echo "Top 100 passages for each dev query are merged."
+
+root="../../data/tct-colbert-v2-marco-passage"
+input_dataset_dir="${root}/dataset"
+output_dataset_dir="${root}/valid_dataset"
+run_path="${root}/dense_output/dev/run.tsv"
+
+python -m repconc.train.run_gen_valid_set \
+    --input_corpus_path $input_dataset_dir/corpus.tsv \
+    --input_query_path $input_dataset_dir/query.dev \
+    --input_qrel_path $input_dataset_dir/qrels.dev \
+    --input_run_path $run_path \
+    --topk 100 \
+    --output_corpus_path $output_dataset_dir/corpus.tsv \
+    --output_query_path $output_dataset_dir/query.dev \
+    --output_qrel_path $output_dataset_dir/qrels.dev 
+    
+echo "Done"

--- a/examples/tct-colbert/msmarco-passage/5_opq_warmup.sh
+++ b/examples/tct-colbert/msmarco-passage/5_opq_warmup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+echo "JPQ and RepCONC both uses Product Quantization technique to compress the index"
+echo "To accelerate convergence, we use OPQ to first warmup the centroids."
+
+subvector=$1
+
+echo "If original dimension == 768, then the compression ratio is 768/${subvector}."
+
+root="../../data/tct-colbert-v2-marco-passage"
+
+input_corpus_embed_path="${root}/dense_output/corpus/corpus_embeds.npy"
+input_corpus_ids_path="${root}/dense_output/corpus/corpus_ids.npy"
+output_model_dir="${root}/subvector-${subvector}/warmup"
+output_index_path="${root}/subvector-${subvector}/warmup_output/corpus/index"
+output_corpus_ids_path="${root}/subvector-${subvector}/warmup_output/corpus/corpus_ids.npy"
+
+model_name_or_path="castorini/tct_colbert-v2-hnp-msmarco"
+MCQ_M=$subvector
+
+python run_tct_warmup.py \
+    --input_corpus_embed_path $input_corpus_embed_path \
+    --input_corpus_ids_path $input_corpus_ids_path \
+    --output_model_dir $output_model_dir \
+    --output_index_path $output_index_path \
+    --output_corpus_ids_path $output_corpus_ids_path \
+    --model_name_or_path $model_name_or_path \
+    --MCQ_M $MCQ_M
+    
+echo "Done"

--- a/examples/tct-colbert/msmarco-passage/README.md
+++ b/examples/tct-colbert/msmarco-passage/README.md
@@ -1,0 +1,70 @@
+# Compressing TCT-ColBERT-V2 on MS MARCO Passage Ranking
+
+This is the instructions about how to transfer [TCT-ColBERT-V2](https://cs.uwaterloo.ca/~jimmylin/publications/Lin_etal_2021_RepL4NLP.pdf) into a memory-efficient dense retrieval model. 
+
+## Retrieval Effectiveness
+
+Here is the effectiveness summarization about different compression methods.
+
+| Models      | PQ Sub-vectors| Index Size  | Compression Ratio | MS MARCO Dev (MRR@10) | TREC 19 DL (NDCG@10) | TREC 20 DL (NDCG@10)
+| -----------       | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
+| TCT-ColBERT-V2-hnp| -  | 26 GB  | 1x  | 0. | 0. | 0. |
+| OPQ (Faiss)       | 48 | 406 MB | 64x | 0. | 0. | 0. | 
+| JPQ               | 48 | 406 MB | 64x | 0. | 0. | 0. | 
+| RepCONC           | 48 | 406 MB | 64x | 0. | 0. | 0. | 
+
+##  Directory Format
+
+The working directory is scheduled to be:
+
+```
+├── data/tct-colbert-v2-marco-passage
+│   ├── dataset (will be downloaded)
+│   ├── valid_dataset (will be generated)
+│   ├── dense_encoder (Path to save SBERT encoder)
+│   ├── dense_output (Path to save the output of SBERT)
+│   ├── subvector-X (X is the number of sub-vectors)
+│   │   ├── warmup (OPQ Warmup of SBERT)
+│   │   ├── warmup_output (OPQ Output of SBERT warmup checkpoint)
+│   │   ├── hardneg.json (hard negatives for repconc training)
+│   │   ├── jpq (training directory of jpq)
+│   │   ├── repconc (training directory of repconc)
+```
+
+## Training Instructions
+
+The following is the training instructions about how to reproduce the above results. The first part is the common procedure of all three methods, such as preparing data. The remaining parts are the instructions for OPQ, JPQ, and RepCONC separately. 
+
+### Common Procedure of OPQ/JPQ/RepCONC
+
+```bash
+cd examples/ance
+
+# Prepare MS MARCO dataset
+sh ./msmarco-passage/1_prepare_dataset.sh
+
+# Let ANCE encode the corpus. We can know whether we reproduce right. And the corpus encoding can be reused by warmup process or JPQ training process.
+# For example, there are 8 gpus available.
+sh ./msmarco-passage/3_encode_dense_corpus.sh 8
+
+# Generate validation set. Sample a small corpus for efficient validation during training.
+sh ./msmarco-passage/4_gen_valid_set.sh
+```
+
+### Index Compression (and Joint Optimization)
+
+The passage representation will be quantized to several sub-vectors. Each sub-vector consumes $1$ byte because the default number of centroids per sub-vector is $256$. 
+That is to say, since TCT-ColBERT encodes passage to a vector of $768$ dimension ($768 \times 4$ bytes), if the number of sub-vectors is $48$ ($48$ bytes), the compression ratio is $768 \times 4/48 = 64$.
+
+Number of sub-vectors is an important hyper-parameter that directly corresponds to the effectiveness-efficiency tradeoff. More sub-vectors result in higher effectiveness but larger memory footprint (and slower retrieval). In this example, we set it to $64$ or $48$. Other value can also be explored as long as 768 is divisible by it.
+
+Warmup the centroids with OPQ. A good warmup accelerates convergence. 
+```bash
+# You can also set number of sub-vectors to 48. (64x compression ratio)
+sh ./msmarco-passage/5_opq_warmup.sh 48
+```
+
+Here are three instructions about reproducing the OPQ, JPQ, and RepCONC results. They are independent from each other. Pick one and follow the instructions.
+- [Evaluating OPQ performance](./opq)
+- [Joint optimization with JPQ](./jpq)
+- [Joint optimization with RepCONC](./repconc)

--- a/examples/tct-colbert/msmarco-passage/jpq/6_run_jpq_train.sh
+++ b/examples/tct-colbert/msmarco-passage/jpq/6_run_jpq_train.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -e
+
+# Distributed training for JPQ is not supported
+# because we do not observe significant efficiency gains.
+
+subvector=$1
+centroid_learning_rate=${2:-1e-4}
+learning_rate=${3:-5e-6}
+per_device_train_batch_size=${4:-128}
+num_train_epochs=${5:-4}
+
+root="../../data/tct-colbert-v2-marco-passage"
+train_data_root="${root}/dataset"
+qrel_path="$train_data_root/qrels.train"
+query_path="$train_data_root/query.train"
+
+valid_data_root="${root}/valid_dataset"
+valid_qrel_path="$valid_data_root/qrels.dev"
+valid_query_path="$valid_data_root/query.dev"
+
+model_name_or_path="${root}/subvector-${subvector}/warmup"
+index_input_dir="${root}/subvector-${subvector}/warmup_output/corpus"
+train_name="query_encoder_l${learning_rate}-cl${centroid_learning_rate}-b${per_device_train_batch_size}"
+output_dir="${root}/subvector-${subvector}/jpq/${train_name}"
+
+echo output_dir: $output_dir
+mkdir -p $output_dir
+timestamp=`date "+%m-%d-%H:%M"`
+log_path="${output_dir}/${timestamp}.log"
+echo log_path: $log_path
+
+python run_tct_train_jpq.py \
+  --qrel_path $qrel_path \
+  --query_path $query_path \
+  --valid_qrel_path $valid_qrel_path \
+  --valid_query_path $valid_query_path \
+  --output_dir $output_dir \
+  --model_name_or_path $model_name_or_path \
+  --index_input_dir $index_input_dir \
+  --logging_steps 100 \
+  --max_query_len 16 \
+  --per_device_train_batch_size $per_device_train_batch_size \
+  --temperature 1 \
+  --gradient_accumulation_steps 1 \
+  --learning_rate $learning_rate \
+  --centroid_learning_rate $centroid_learning_rate \
+  --num_train_epochs $num_train_epochs \
+  --dataloader_drop_last \
+  --overwrite_output_dir \
+  --dataloader_num_workers 0 \
+  --weight_decay 0 \
+  --lr_scheduler_type "constant" \
+  --metric_for_best_model MRR@10 \
+  --save_total_limit 2 \
+  --evaluation_strategy "steps" \
+  --save_strategy "steps" \
+  --save_steps 1000 \
+  --eval_steps 1000 \
+  --load_best_model_at_end \
+  --optim adamw_torch \
+  |& tee $log_path   
+
+cd "${root}/subvector-${subvector}/jpq"
+if [ -f "query_encoder" ]; then
+    echo "query_encoder symbolic already exists."
+else 
+    ln -s "$train_name" "query_encoder"
+fi

--- a/examples/tct-colbert/msmarco-passage/jpq/7_run_jpq_eval.sh
+++ b/examples/tct-colbert/msmarco-passage/jpq/7_run_jpq_eval.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+gpus=$1
+subvector=$2
+
+root="../../data/tct-colbert-v2-marco-passage"
+dataset_dir="${root}/dataset"
+doc_encoder_path="${root}/subvector-${subvector}/warmup"
+query_encoder_path="${root}/subvector-${subvector}/jpq/query_encoder"
+output_dir="${root}/subvector-${subvector}/jpq/query_results"
+
+mkdir -p $output_dir
+
+# will load corpus index from this dir
+out_corpus_dir="${root}/subvector-${subvector}/warmup_output/corpus"
+ 
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+for mode in "trec19" "trec20" "dev" 
+do
+    timestamp=`date "+%m-%d-%H:%M"`
+    log_path="${output_dir}/${timestamp}.log"
+    echo log_path: $log_path
+    
+    python $distributed_cmd \
+        run_tct_repconc_eval.py \
+        --corpus_path "${dataset_dir}/corpus.tsv" \
+        --query_path "${dataset_dir}/query.${mode}" \
+        --output_dir $output_dir \
+        --out_corpus_dir $out_corpus_dir \
+        --out_query_dir "${output_dir}/${mode}" \
+        --qrel_path "${dataset_dir}/qrels.${mode}" \
+        --doc_encoder_path $doc_encoder_path \
+        --query_encoder_path $query_encoder_path \
+        --per_device_eval_batch_size 64 \
+        --dataloader_num_workers 4 \
+        |& tee $log_path   
+done
+  

--- a/examples/tct-colbert/msmarco-passage/jpq/README.md
+++ b/examples/tct-colbert/msmarco-passage/jpq/README.md
@@ -1,0 +1,30 @@
+# Compressing TCT-ColBERT-V2 on MS MARCO Passage Ranking
+
+Here, we assume you have already follow the [previous instructions](..). 
+
+
+### JPQ Optimization
+
+JPQ further trains the query encoder and PQ Centroids.
+
+```bash
+# JPQ uses 1 gpu for training. Multi-gpu does not provide additional training efficiency gains according to our experiments. 
+# number of sub-vectors is set to 48.
+sh ./msmarco-passage/jpq/6_run_jpq_train.sh 48
+```
+
+
+### JPQ Evaluation
+
+JPQ re-encodes the queries. It loads the index of the warmup checkpoint and substitutes the PQ centroids with the newly trained ones.
+
+```bash
+# For example, 
+# number of gpus to use is 1 (first argument)
+# Encoding queries is fast and does not need multi-gpu inference.
+
+# number of sub-vectors is set to 48. 
+sh ./msmarco-passage/jpq/7_run_jpq_eval.sh 1 48
+# For example, here is the performance on MS MARCO dev set.
+more ../../data/tct-colbert-v2-marco-passage/subvector-48/jpq/query_results/dev/metric.json 
+```

--- a/examples/tct-colbert/msmarco-passage/opq/6_run_opq_eval.sh
+++ b/examples/tct-colbert/msmarco-passage/opq/6_run_opq_eval.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+echo "Since we have already run OPQ in the warmup script, now we reuse the index and evaluate the efficacy of OPQ."
+
+gpus=$1
+subvector=$2
+
+root="../../data/tct-colbert-v2-marco-passage"
+dataset_dir="${root}/dataset"
+doc_encoder_path="${root}/subvector-${subvector}/warmup"
+query_encoder_path="${root}/subvector-${subvector}/warmup"
+output_dir="${root}/subvector-${subvector}/warmup_output"
+
+mkdir -p $output_dir
+out_corpus_dir="$output_dir/corpus"
+
+corpus_path="$dataset_dir/corpus.tsv"
+
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+for mode in "trec19" "trec20" "dev" 
+do
+    timestamp=`date "+%m-%d-%H:%M"`
+    log_path="${output_dir}/${timestamp}.log"
+
+    python $distributed_cmd \
+        run_tct_repconc_eval.py \
+        --corpus_path $corpus_path \
+        --query_path "$dataset_dir/query.${mode}" \
+        --qrel_path "$dataset_dir/qrels.${mode}" \
+        --output_dir $output_dir \
+        --out_corpus_dir $out_corpus_dir \
+        --out_query_dir "$output_dir/${mode}" \
+        --doc_encoder_path $doc_encoder_path \
+        --query_encoder_path $query_encoder_path \
+        --per_device_eval_batch_size 64 \
+        --max_seq_length 512 \
+        --dataloader_num_workers 1 \
+        |& tee -a $log_path   
+done
+

--- a/examples/tct-colbert/msmarco-passage/opq/README.md
+++ b/examples/tct-colbert/msmarco-passage/opq/README.md
@@ -1,0 +1,18 @@
+# Compressing TCT-ColBERT-V2 on MS MARCO Passage Ranking
+
+Here, we assume you have already follow the [previous instructions](..). Since the warmup process uses OPQ, now you can simply evaluate the effectiveness of the warmup checkpoint.
+
+
+### OPQ Evaluation
+
+```bash
+# For example, 
+# number of gpus to use is 1 (first argument)
+# Only query encoding is required.
+
+# number of sub-vectors is set to 48.
+sh ./msmarco-passage/opq/6_run_opq_eval.sh 1 48
+# For example, here is the performance on MS MARCO dev set.
+more ../../data/tct-colbert-v2-marco-passage/subvector-48/warmup_output/dev/metric.json 
+```
+

--- a/examples/tct-colbert/msmarco-passage/repconc/10_run_jpq_eval.sh
+++ b/examples/tct-colbert/msmarco-passage/repconc/10_run_jpq_eval.sh
@@ -1,0 +1,49 @@
+mkdir -p $output_dir
+#!/bin/bash
+
+set -e
+
+echo "Evaluate the finetuned query encoder."
+
+gpus=$1
+subvector=$2
+
+root="../../data/tct-colbert-v2-marco-passage"
+dataset_dir="${root}/dataset"
+doc_encoder_path="${root}/subvector-${subvector}/repconc/doc_encoder"
+query_encoder_path="${root}/subvector-${subvector}/repconc/query_encoder"
+output_dir="${root}/subvector-${subvector}/repconc/query_encoder_results"
+
+mkdir -p $output_dir
+
+# will load corpus index from this dir
+out_corpus_dir="${root}/subvector-${subvector}/repconc/encoder_output/corpus"
+ 
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+timestamp=`date "+%m-%d-%H:%M"`
+log_path="${output_dir}/${timestamp}.log"
+echo log_path: $log_path
+
+for mode in "trec19" "trec20" "dev" ; do
+    python $distributed_cmd \
+        run_tct_repconc_eval.py \
+        --corpus_path "${dataset_dir}/corpus.tsv" \
+        --query_path "${dataset_dir}/query.${mode}" \
+        --output_dir $output_dir \
+        --out_corpus_dir $out_corpus_dir \
+        --out_query_dir "${output_dir}/${mode}" \
+        --qrel_path "${dataset_dir}/qrels.${mode}" \
+        --doc_encoder_path $doc_encoder_path \
+        --query_encoder_path $query_encoder_path \
+        --per_device_eval_batch_size 64 \
+        --dataloader_num_workers 4 \
+        |& tee $log_path   
+done
+  

--- a/examples/tct-colbert/msmarco-passage/repconc/6_gen_hardneg.sh
+++ b/examples/tct-colbert/msmarco-passage/repconc/6_gen_hardneg.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e
+
+gpus=$1
+subvector=$2
+
+echo "Generate hard negatives for training RepCONC"
+echo "Why hard negatives are necessary? Please refer to https://arxiv.org/pdf/2104.08051.pdf "
+
+root="../../data/tct-colbert-v2-marco-passage"
+dataset_dir="${root}/dataset"
+corpus_path="$dataset_dir/corpus.tsv"
+query_path="$dataset_dir/query.train"
+qrel_path="$dataset_dir/qrels.train"
+
+hardneg_path="${root}/subvector-${subvector}/hardneg.json"
+
+model_path="${root}/subvector-${subvector}/warmup"
+output_dir="${root}/subvector-${subvector}/warmup_output"
+out_corpus_dir="${output_dir}/corpus"
+out_query_dir="${output_dir}/train"
+
+dataloader_num_workers=1
+
+timestamp=`date "+%m-%d-%H:%M"`
+log_path="${output_dir}/${timestamp}.log"
+
+mkdir -p $output_dir
+
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+python $distributed_cmd \
+    run_tct_repconc_eval.py \
+    --corpus_path $corpus_path \
+    --query_path $query_path \
+    --output_dir $output_dir \
+    --out_corpus_dir $out_corpus_dir \
+    --out_query_dir "$out_query_dir" \
+    --model_name_or_path $model_path \
+    --per_device_eval_batch_size 64 \
+    --max_seq_length 512 \
+    --topk 200 \
+    --dataloader_num_workers $dataloader_num_workers \
+    |& tee -a $log_path   
+
+
+python -m repconc.train.run_extract_hardneg \
+    --run_path "${out_query_dir}/run.tsv" \
+    --qrel_path "$qrel_path" \
+    --topk 200 \
+    --output_path $hardneg_path
+
+echo "Done"

--- a/examples/tct-colbert/msmarco-passage/repconc/7_run_conc_train.sh
+++ b/examples/tct-colbert/msmarco-passage/repconc/7_run_conc_train.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -e
+
+echo "Run RepCONC training stage #1 (https://arxiv.org/pdf/2110.05789.pdf) "
+echo "Hint for tuning hyper-parameters"
+echo "- If mse_loss_weight is too large, MSE loss dominates and harms ranking effectiveness. If too small, PQ centroids and dense representations are loosely bounded and performance degenerates."
+echo "- Learning rate for centroids should be much larger than that for dense encoder. (Roughly 10x - 30x for bert-base encoder)."
+echo "- We sample negative_per_query negatives for each query. It affects training efficiency and effectiveness. If it is to small, training is fast but effectiveness is not very good. 11 is relatively good for MS MARCO Passage. You can also use 7 or 3 if you have limited machines."
+echo "- full_batch_size is the number of queries per batch. We use relatively large one (4096). We also observe that 2048 also works."
+echo "- cache_chunk_size is the batch size per forward. If you have limited cuda memory, you may not need to use smaller batch size but just need to set a smaller cache_chunk_size. "
+
+gpus=$1
+subvector=$2
+mse_loss_weight=${3:-1e-4}
+centroid_learning_rate=${4:-5e-4}
+learning_rate=${5:-2e-5}
+negative_per_query=${6:-11}
+full_batch_size=${7:-4096}
+num_train_epochs=${8:-6}
+
+per_device_train_batch_size=$(( $full_batch_size / $gpus ))
+
+echo negative_per_query: $negative_per_query
+
+if [ $((gpus * per_device_train_batch_size)) != $full_batch_size ]
+then
+    echo "Per device batch size not a integer"
+    exit
+fi
+
+echo full_batch_size: $full_batch_size
+
+root="../../data/tct-colbert-v2-marco-passage"
+train_data_root="${root}/dataset"
+qrel_path="$train_data_root/qrels.train"
+query_path="$train_data_root/query.train"
+corpus_path="$train_data_root/corpus.tsv"
+
+valid_data_root="${root}/valid_dataset"
+valid_qrel_path="$valid_data_root/qrels.dev"
+valid_query_path="$valid_data_root/query.dev"
+valid_corpus_path="$valid_data_root/corpus.tsv"
+
+model_name_or_path="${root}/subvector-${subvector}/warmup"
+hardneg_path="${root}/subvector-${subvector}/hardneg.json"
+train_name="encoder_l${learning_rate}-cl${centroid_learning_rate}-b${full_batch_size}-m${mse_loss_weight}-n${negative_per_query}-gpu${gpus}"
+output_dir="${root}/subvector-${subvector}/repconc/${train_name}"
+
+echo output_dir: $output_dir
+mkdir -p $output_dir
+timestamp=`date "+%m-%d-%H:%M"`
+log_path="${output_dir}/${timestamp}.log"
+echo log_path: $log_path
+
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+python $distributed_cmd \
+  run_tct_train_conc.py \
+  --qrel_path $qrel_path \
+  --query_path $query_path \
+  --corpus_path $corpus_path \
+  --valid_qrel_path $valid_qrel_path \
+  --valid_query_path $valid_query_path \
+  --valid_corpus_path $valid_corpus_path \
+  --output_dir $output_dir \
+  --model_name_or_path $model_name_or_path \
+  --logging_steps 5 \
+  --max_query_len 16 \
+  --max_doc_len 128 \
+  --per_device_train_batch_size $per_device_train_batch_size \
+  --per_device_eval_batch_size 32 \
+  --temperature 1 \
+  --gradient_accumulation_steps 1 \
+  --fp16 \
+  --negative_per_query $negative_per_query \
+  --dynamic_topk_hard_negative $negative_per_query \
+  --learning_rate $learning_rate \
+  --centroid_learning_rate $centroid_learning_rate \
+  --num_train_epochs $num_train_epochs \
+  --dataloader_drop_last \
+  --overwrite_output_dir \
+  --dataloader_num_workers 0 \
+  --weight_decay 0 \
+  --lr_scheduler_type "constant" \
+  --cache_chunk_size 64 \
+  --mse_loss_weight $mse_loss_weight \
+  --negative $hardneg_path \
+  --sk_epsilon 0.003 \
+  --sk_iters 100 \
+  --metric_for_best_model MRR@10 \
+  --save_total_limit 2 \
+  --evaluation_strategy "steps" \
+  --save_strategy "steps" \
+  --eval_steps 40 \
+  --save_steps 40 \
+  --load_best_model_at_end \
+  --optim adamw_torch \
+  |& tee $log_path   
+
+cd "${root}/subvector-${subvector}/repconc"
+if [ -f "encoder" ]; then
+    echo "encoder symbolic already exists."
+else 
+    ln -s "$train_name" "encoder"
+fi

--- a/examples/tct-colbert/msmarco-passage/repconc/8_run_conc_eval.sh
+++ b/examples/tct-colbert/msmarco-passage/repconc/8_run_conc_eval.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+echo "Evaluate the encoder trained by RepCONC. It will encode passages to discrete representations to facilitate compact index. "
+
+gpus=$1
+subvector=$2
+
+root="../../data/tct-colbert-v2-marco-passage"
+dataset_dir="${root}/dataset"
+model_path="${root}/subvector-${subvector}/repconc/encoder"
+output_dir="${root}/subvector-${subvector}/repconc/encoder_output"
+
+mkdir -p $output_dir
+out_corpus_dir="$output_dir/corpus"
+
+corpus_path="$dataset_dir/corpus.tsv"
+
+if [ $gpus = 1 ]
+then
+    distributed_cmd=" "
+else
+    master_port=$(eval "shuf -i 10000-15000 -n 1")
+    distributed_cmd=" -m torch.distributed.launch --nproc_per_node $gpus --master_port=$master_port "
+fi
+
+for mode in "trec19" "trec20" "dev" 
+do
+    timestamp=`date "+%m-%d-%H:%M"`
+    log_path="${output_dir}/${timestamp}.log"
+
+    python $distributed_cmd \
+        run_tct_repconc_eval.py \
+        --corpus_path $corpus_path \
+        --query_path "$dataset_dir/query.${mode}" \
+        --qrel_path "$dataset_dir/qrels.${mode}" \
+        --output_dir $output_dir \
+        --out_corpus_dir $out_corpus_dir \
+        --out_query_dir "$output_dir/${mode}" \
+        --doc_encoder_path $model_path \
+        --query_encoder_path $model_path \
+        --per_device_eval_batch_size 64 \
+        --max_seq_length 512 \
+        --dataloader_num_workers 1 \
+        |& tee -a $log_path   
+done
+

--- a/examples/tct-colbert/msmarco-passage/repconc/9_run_jpq_train.sh
+++ b/examples/tct-colbert/msmarco-passage/repconc/9_run_jpq_train.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+echo "This script further finetunes the query encoder with JPQ. It is optional because the effectiveness gains is marginal if the previous training stage uses very large batch size."
+echo "JPQ uses the previously trained encoder for initialization. It fixes the index assignments and trains the query encoder and centroids. (https://arxiv.org/abs/2108.00644)"
+echo "Currently, Distributed training for JPQ is not supported because we do not observe significant efficiency gains."
+
+subvector=$1
+centroid_learning_rate=${2:-2e-5}
+learning_rate=${3:-2e-6}
+per_device_train_batch_size=${4:-128}
+num_train_epochs=${5:-4}
+
+root="../../data/tct-colbert-v2-marco-passage"
+train_data_root="${root}/dataset"
+qrel_path="$train_data_root/qrels.train"
+query_path="$train_data_root/query.train"
+
+valid_data_root="${root}/valid_dataset"
+valid_qrel_path="$valid_data_root/qrels.dev"
+valid_query_path="$valid_data_root/query.dev"
+
+model_name_or_path="${root}/subvector-${subvector}/repconc/encoder"
+index_input_dir="${root}/subvector-${subvector}/repconc/encoder_output/corpus"
+train_name="query_encoder_l${learning_rate}-cl${centroid_learning_rate}-b${per_device_train_batch_size}"
+output_dir="${root}/subvector-${subvector}/repconc/${train_name}"
+
+echo output_dir: $output_dir
+mkdir -p $output_dir
+timestamp=`date "+%m-%d-%H:%M"`
+log_path="${output_dir}/${timestamp}.log"
+echo log_path: $log_path
+
+python run_tct_train_jpq.py \
+  --qrel_path $qrel_path \
+  --query_path $query_path \
+  --valid_qrel_path $valid_qrel_path \
+  --valid_query_path $valid_query_path \
+  --output_dir $output_dir \
+  --model_name_or_path $model_name_or_path \
+  --index_input_dir $index_input_dir \
+  --logging_steps 100 \
+  --max_query_len 16 \
+  --per_device_train_batch_size $per_device_train_batch_size \
+  --temperature 1 \
+  --gradient_accumulation_steps 1 \
+  --learning_rate $learning_rate \
+  --centroid_learning_rate $centroid_learning_rate \
+  --num_train_epochs $num_train_epochs \
+  --dataloader_drop_last \
+  --overwrite_output_dir \
+  --dataloader_num_workers 0 \
+  --weight_decay 0 \
+  --lr_scheduler_type "constant" \
+  --metric_for_best_model MRR@10 \
+  --save_total_limit 2 \
+  --evaluation_strategy "steps" \
+  --save_strategy "steps" \
+  --save_steps 1000 \
+  --eval_steps 1000 \
+  --load_best_model_at_end \
+  --optim adamw_torch \
+  |& tee $log_path   
+
+cd "${root}/subvector-${subvector}/repconc"
+if [ -f "query_encoder" ]; then
+    echo "query_encoder symbolic already exists."
+else 
+    ln -s "$train_name" "query_encoder"
+fi

--- a/examples/tct-colbert/msmarco-passage/repconc/README.md
+++ b/examples/tct-colbert/msmarco-passage/repconc/README.md
@@ -1,0 +1,46 @@
+# Compressing TCT-ColBERT-V2 on MS MARCO Passage Ranking
+
+Here, we assume you have already follow the [previous instructions](..). 
+
+RepCONC has two training stages. In the first stage, it trains the query encoder and passage encoder by minimizing ranking loss and quantization loss. In the second stage, it trains the query encoder and PQ centroids with only ranking loss. 
+
+The following instructions set the number of sub-vectors to $48$. You can also set it to other values.
+
+### RepCONC Training STAGE-1
+
+*Note: In stage-1, we use distributed training for acceleration. We train the models on 8 NVIDIA-V100 GPUs for about 3.5 hours. If you use different numbers of GPUs, it is possible that you need to tune the learning rate accordingly because: [PyTorch averages gradients across all nodes. When a model is trained on M nodes with batch=N, the gradient will be M times smaller when compared to the same model trained on a single node with batch=M*N. You can use a smaller learning rate when training with fewer gpus.](https://pytorch.org/docs/master/generated/torch.nn.parallel.DistributedDataParallel.html#torch.nn.parallel.DistributedDataParallel). That said, we find RepCONC is not sensitive to different learning rate and you can just use the learning rate in this example as default values.*
+
+```bash
+# For example, 
+# number of gpus to use is 8 (first argument)
+
+# Generate hard negatives
+sh ./msmarco-passage/repconc/6_gen_hardneg.sh 8 48
+
+# Run training
+sh ./msmarco-passage/repconc/7_run_conc_train.sh 8 48
+
+# Encodes the corpus
+sh ./msmarco-passage/repconc/8_run_conc_eval.sh 8 48
+
+# For example, here is the performance on MS MARCO dev set after stage-1 training.
+more ../../data/tct-colbert-v2-marco-passage/subvector-48/repconc/encoder_output/dev/metric.json 
+```
+
+
+### RepCONC Training STAGE-2
+
+```bash
+# For example, 
+# number of gpus to use is 1 (first argument)
+# Encoding queries is fast and does not need multi-gpu inference.
+
+# Run training
+sh ./msmarco-passage/repconc/9_run_jpq_train.sh 48
+
+# Evaluation
+sh ./msmarco-passage/repconc/10_run_jpq_eval.sh 48
+
+# For example, here is the performance on MS MARCO dev set.
+more ../../data/tct-colbert-v2-marco-passage/subvector-48/repconc/query_encoder_results/dev/metric.json 
+```

--- a/examples/tct-colbert/run_tct_dense_eval.py
+++ b/examples/tct-colbert/run_tct_dense_eval.py
@@ -1,0 +1,59 @@
+import os
+import torch
+import logging
+import transformers
+from transformers import (
+    AutoTokenizer, 
+    HfArgumentParser, 
+    set_seed)
+from transformers.trainer_utils import is_main_process
+
+from repconc.evaluate.run_dense_eval import (
+    DataArguments, 
+    ModelArguments, 
+    EvalArguments,
+    load_or_encode_query,
+    load_or_encode_corpus,
+    search_and_compute_metrics
+)
+
+from modeling_tct import TCTEncoder, TCTTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+    
+def main():
+    parser = HfArgumentParser((ModelArguments, DataArguments, EvalArguments))
+    model_args, data_args, eval_args = parser.parse_args_into_dataclasses()
+
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO if is_main_process(eval_args.local_rank) else logging.WARN,
+    )
+    if is_main_process(eval_args.local_rank):
+        transformers.utils.logging.set_verbosity_info()
+        transformers.utils.logging.enable_default_handler()
+        transformers.utils.logging.enable_explicit_format()
+    set_seed(2022)
+
+    ### Only here is modified for ANCE
+    tokenizer = TCTTokenizerFast.from_pretrained(model_args.model_name_or_path)
+    model = TCTEncoder.from_pretrained(model_args.model_name_or_path)
+    ###
+
+    corpus_embeds, corpus_ids = load_or_encode_corpus(model, tokenizer, model_args, data_args, eval_args)
+
+    query_embeds, query_ids = load_or_encode_query(model, tokenizer, data_args.query_path, data_args.out_query_dir, model_args, data_args, eval_args)
+    out_metric_path = os.path.join(data_args.out_query_dir, "metric.json")
+    torch.cuda.empty_cache()
+    if is_main_process(eval_args.local_rank) and not os.path.exists(out_metric_path):
+        os.makedirs(data_args.out_query_dir, exist_ok=True)
+        search_and_compute_metrics(corpus_embeds, corpus_ids, query_embeds, query_ids, out_metric_path, data_args.out_query_dir, data_args.qrel_path, eval_args)
+    else:
+        # only main process can print, so this line is only printed when the metric file exists
+        logger.info("Skip search process because metric.json file already exists. ")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tct-colbert/run_tct_repconc_eval.py
+++ b/examples/tct-colbert/run_tct_repconc_eval.py
@@ -1,0 +1,121 @@
+import os
+import faiss
+import logging
+import numpy as np
+import transformers
+from transformers import (
+    HfArgumentParser, 
+    set_seed)
+from transformers.trainer_utils import is_main_process
+
+from repconc.models.repconc.evaluate_repconc import (
+    ModelArguments, 
+    EvalArguments, 
+)
+from repconc.utils.eval_utils import (
+    load_corpus, 
+    load_queries,
+    DataArguments, 
+    load_beir_corpus,
+    load_beir_queries,
+)
+from repconc.models.repconc.evaluate_repconc import (
+    ModelArguments, 
+    EvalArguments, 
+    encode_corpus, 
+    encode_query,
+)
+from repconc.evaluate.run_repconc_eval import (
+    search_and_compute_metrics,
+)
+
+from modeling_tct import TCTTokenizerFast, tct_repconc_from_pretrained
+logger = logging.getLogger(__name__)
+
+
+def load_or_encode_corpus(model_args: ModelArguments, data_args: DataArguments, eval_args: EvalArguments):
+    out_index_path = os.path.join(data_args.out_corpus_dir, "index")
+    out_corpus_ids_path = os.path.join(data_args.out_corpus_dir, "corpus_ids.npy")
+    if os.path.exists(out_index_path) and os.path.exists(out_corpus_ids_path):
+        index = faiss.read_index(out_index_path)
+        corpus_ids = np.load(out_corpus_ids_path)
+        logger.info("Load pre-computed corpus representations")
+    else:
+        doc_tokenizer = TCTTokenizerFast.from_pretrained(model_args.doc_encoder_path)
+        doc_encoder = tct_repconc_from_pretrained(model_args.doc_encoder_path, False, None, None)
+        if data_args.data_format == "msmarco":
+            corpus = load_corpus(data_args.corpus_path, doc_tokenizer.sep_token, verbose=is_main_process(eval_args.local_rank))
+        elif data_args.data_format == "beir":
+            corpus = load_beir_corpus(data_args.corpus_path, doc_tokenizer.sep_token, verbose=is_main_process(eval_args.local_rank))
+        else:
+            raise NotImplementedError()
+        index, corpus_ids = encode_corpus(corpus, doc_encoder, doc_tokenizer, model_args.max_seq_length, eval_args)
+        if is_main_process(eval_args.local_rank):
+            os.makedirs(data_args.out_corpus_dir, exist_ok=True)
+            faiss.write_index(index, out_index_path)
+            np.save(out_corpus_ids_path, corpus_ids)
+    return index, corpus_ids
+
+
+def load_or_encode_queries(model_args: ModelArguments, data_args: DataArguments, eval_args: EvalArguments):
+    out_query_code_path = os.path.join(data_args.out_query_dir, "codes.npy")
+    out_query_ids_path = os.path.join(data_args.out_query_dir, "qids.npy")
+    if os.path.exists(out_query_code_path) and os.path.exists(out_query_ids_path):
+        query_embeds = np.load(out_query_code_path)
+        query_ids = np.load(out_query_ids_path)
+        logger.info("Load pre-computed query representations")
+    else:
+        query_tokenizer = TCTTokenizerFast.from_pretrained(model_args.query_encoder_path)
+        query_encoder = tct_repconc_from_pretrained(model_args.query_encoder_path, False, None, None)
+        if data_args.data_format == "msmarco":
+            queries = load_queries(data_args.query_path)
+        elif data_args.data_format == "beir":
+            queries = load_beir_queries(data_args.query_path)
+        else:
+            raise NotImplementedError()
+        query_embeds, query_ids = encode_query(queries, query_encoder, query_tokenizer, model_args.max_seq_length, eval_args)
+        if is_main_process(eval_args.local_rank):
+            os.makedirs(data_args.out_query_dir, exist_ok=True)
+            np.save(out_query_code_path, query_embeds)
+            np.save(out_query_ids_path, query_ids)
+    return query_embeds, query_ids
+
+
+def replace_pq_centroids(index: faiss.IndexPQ, query_encoder_path: str):
+    query_encoder = tct_repconc_from_pretrained(query_encoder_path, False, None, None)
+    centroids = query_encoder.centroids.data.detach().cpu().numpy().ravel()
+    faiss.copy_array_to_vector(centroids, index.pq.centroids)
+    return index
+
+
+def main():
+    parser = HfArgumentParser((ModelArguments, DataArguments, EvalArguments))
+    model_args, data_args, eval_args = parser.parse_args_into_dataclasses()
+
+    model_args: ModelArguments
+    data_args: DataArguments
+    eval_args: EvalArguments
+
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO if is_main_process(eval_args.local_rank) else logging.WARN,
+    )
+    if is_main_process(eval_args.local_rank):
+        transformers.utils.logging.set_verbosity_info()
+        transformers.utils.logging.enable_default_handler()
+        transformers.utils.logging.enable_explicit_format()
+
+    set_seed(2022)
+    faiss.omp_set_num_threads(eval_args.threads)
+
+    index, corpus_ids = load_or_encode_corpus(model_args, data_args, eval_args)
+    query_embeds, query_ids = load_or_encode_queries(model_args, data_args, eval_args)
+    index = replace_pq_centroids(index, model_args.query_encoder_path)
+
+    if is_main_process(eval_args.local_rank):
+        search_and_compute_metrics(index, corpus_ids, query_embeds, query_ids, data_args, eval_args)
+        
+
+if __name__ == "__main__":
+    main()

--- a/examples/tct-colbert/run_tct_train_conc.py
+++ b/examples/tct-colbert/run_tct_train_conc.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import logging
+import transformers
+from transformers import (
+    HfArgumentParser,
+    set_seed, )
+from transformers.trainer_utils import is_main_process
+
+from repconc.models.repconc.finetune_repconc import (
+    RepCONCFinetuner, 
+    RepCONCFinetuneArguments, 
+    QDRelDataset, 
+    FinetuneCollator, 
+    DataTrainingArguments
+)
+from repconc.train.run_train_conc import (
+    ModelArguments,
+    load_validation_set
+)
+
+from modeling_tct import tct_repconc_from_pretrained, TCTTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    # See all possible arguments in src/transformers/training_args.py
+    # or by passing the --help flag to this script.
+    # We now keep distinct sets of args, for a cleaner separation of concerns.
+
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, RepCONCFinetuneArguments))
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s-%(levelname)s-%(name)s- %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO if is_main_process(training_args.local_rank) else logging.WARN,
+    )
+    
+    resume_from_checkpoint = False
+    if (
+            os.path.exists(training_args.output_dir)
+            and os.listdir(training_args.output_dir)
+            and any((x.startswith("checkpoint") for x in os.listdir(training_args.output_dir)))
+    ):
+        if not training_args.overwrite_output_dir:
+            raise ValueError(
+                f"Output directory ({training_args.output_dir}) already exists and is not empty. "
+                "Use --overwrite_output_dir to overcome."
+            )
+        else:
+            resume_from_checkpoint = True
+
+    model_args: ModelArguments
+    data_args: DataTrainingArguments
+    training_args: RepCONCFinetuneArguments
+
+    # Log on each process the small summary:
+    logger.warning(
+        f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+        + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+    )
+    # Set the verbosity to info of the Transformers logger (on main process only):
+    if is_main_process(training_args.local_rank):
+        transformers.utils.logging.set_verbosity_info()
+        transformers.utils.logging.enable_default_handler()
+        transformers.utils.logging.enable_explicit_format()
+    logger.info("Model parameters %s", model_args)
+    logger.info("Data parameters %s", data_args)
+    logger.info("Training parameters %s", training_args)
+
+    # Set seed before initializing model.
+    set_seed(training_args.seed)
+    
+    ### only here is modified
+    tokenizer = TCTTokenizerFast.from_pretrained(
+        model_args.model_name_or_path, 
+    )
+    repconc = tct_repconc_from_pretrained(
+        model_args.model_name_or_path, 
+        use_constraint = not training_args.not_use_constraint, 
+        sk_epsilon = model_args.sk_epsilon, 
+        sk_iters = model_args.sk_iters)
+    ###
+
+    eval_dataset=load_validation_set(
+        data_args.valid_corpus_path,
+        data_args.valid_query_path,
+        data_args.valid_qrel_path,
+        sep_token = tokenizer.sep_token
+    )
+    train_set = QDRelDataset(tokenizer, 
+            qrel_path = data_args.qrel_path, 
+            query_path = data_args.query_path, 
+            corpus_path = data_args.corpus_path, 
+            max_query_len = data_args.max_query_len, 
+            max_doc_len = data_args.max_doc_len, 
+            negative = training_args.negative,
+            negative_per_query = training_args.negative_per_query,
+            rel_threshold=1, 
+            verbose=is_main_process(training_args.local_rank))
+    # Data collator
+    data_collator = FinetuneCollator(
+        tokenizer=tokenizer,
+        max_query_len = data_args.max_query_len, 
+        max_doc_len = data_args.max_doc_len,
+    )
+    # Initialize our Trainer
+    trainer = RepCONCFinetuner(
+        qrels=train_set.get_qrels(),
+        model=repconc,
+        args=training_args,
+        train_dataset=train_set,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        eval_dataset=eval_dataset
+    )
+    # additionally save checkpoint at the end of one epoch
+
+    trainer.train(resume_from_checkpoint=resume_from_checkpoint)
+    trainer.save_model()
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tct-colbert/run_tct_train_jpq.py
+++ b/examples/tct-colbert/run_tct_train_jpq.py
@@ -1,0 +1,138 @@
+import os
+import sys
+import faiss
+import logging
+import numpy as np
+import transformers
+from transformers import (
+    HfArgumentParser,
+    set_seed, )
+from transformers.trainer_utils import is_main_process
+
+from repconc.models.jpq.finetune_jpq import (
+    JPQ, 
+    QueryDataset,
+    JPQFinetuneArguments, 
+    FinetuneQueryCollator,
+    JPQFinetuner, 
+    DataTrainingArguments
+)
+from repconc.train.run_train_jpq import (
+    ModelArguments,
+    load_validation_set
+)
+
+from modeling_tct import TCTTokenizerFast, tct_repconc_from_pretrained
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    # See all possible arguments in src/transformers/training_args.py
+    # or by passing the --help flag to this script.
+    # We now keep distinct sets of args, for a cleaner separation of concerns.
+
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, JPQFinetuneArguments))
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s-%(levelname)s-%(name)s- %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO if is_main_process(training_args.local_rank) else logging.WARN,
+    )
+    
+    resume_from_checkpoint = False
+    if (
+            os.path.exists(training_args.output_dir)
+            and os.listdir(training_args.output_dir)
+            and any((x.startswith("checkpoint") for x in os.listdir(training_args.output_dir)))
+    ):
+        if not training_args.overwrite_output_dir:
+            raise ValueError(
+                f"Output directory ({training_args.output_dir}) already exists and is not empty. "
+                "Use --overwrite_output_dir to overcome."
+            )
+        else:
+            resume_from_checkpoint = True
+
+    model_args: ModelArguments
+    data_args: DataTrainingArguments
+    training_args: JPQFinetuneArguments
+
+    # Log on each process the small summary:
+    logger.warning(
+        f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+        + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+    )
+    # Set the verbosity to info of the Transformers logger (on main process only):
+    if is_main_process(training_args.local_rank):
+        transformers.utils.logging.set_verbosity_info()
+        transformers.utils.logging.enable_default_handler()
+        transformers.utils.logging.enable_explicit_format()
+    logger.info("Model parameters %s", model_args)
+    logger.info("Data parameters %s", data_args)
+    logger.info("Training parameters %s", training_args)
+
+    assert training_args.n_gpu == 1, "Not sure whether Faiss supports distributed training with Pytorch."
+    # Set seed before initializing model.
+    set_seed(training_args.seed)
+
+    ### Only here is modified
+    tokenizer = TCTTokenizerFast.from_pretrained(model_args.model_name_or_path)
+    repconc = tct_repconc_from_pretrained(model_args.model_name_or_path, use_constraint=False, sk_epsilon=None, sk_iters=None)
+    ###
+
+    pq_index = faiss.read_index(os.path.join(model_args.index_input_dir, "index"))
+    corpus_ids = np.load(os.path.join(model_args.index_input_dir, "corpus_ids.npy"))
+    valid_queries, valid_qrels = load_validation_set(data_args.valid_query_path, data_args.valid_qrel_path)
+
+    train_set = QueryDataset(tokenizer, 
+            qrel_path = data_args.qrel_path, 
+            query_path = data_args.query_path, 
+            max_query_len = data_args.max_query_len, 
+            index_doc_ids = corpus_ids,
+            rel_threshold=1, 
+            verbose=is_main_process(training_args.local_rank))
+    # Data collator
+    data_collator = FinetuneQueryCollator(
+        tokenizer=tokenizer,
+        max_query_len = data_args.max_query_len, 
+    )
+
+    jpq = JPQ(
+        repconc = repconc, 
+        pq_index = pq_index, 
+        qrels = train_set.get_qrels(), 
+        neg_top_k = training_args.dynamic_topk_negative, 
+        temperature = training_args.temperature,
+        gpu_id = 0 if training_args.local_rank == -1 else training_args.local_rank,
+    )
+    # Initialize our Trainer
+    trainer = JPQFinetuner(
+        model=jpq,
+        args=training_args,
+        train_dataset=train_set,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        eval_dataset=(corpus_ids, valid_queries, valid_qrels)
+    )
+    # additionally save checkpoint at the end of one epoch
+    trainer.train(resume_from_checkpoint=resume_from_checkpoint)
+
+    # make sure load_best_model_at_end = True
+    trainer.save_model()
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tct-colbert/run_tct_warmup.py
+++ b/examples/tct-colbert/run_tct_warmup.py
@@ -1,0 +1,82 @@
+import os
+import faiss
+import logging
+import numpy as np
+from transformers import (
+    HfArgumentParser,
+    set_seed, )
+
+from repconc.models.repconc import RepCONC
+
+from repconc.train.run_warmup import (
+    DataArguments,
+    ModelArguments,
+    warmup_from_embeds
+)
+
+from modeling_tct import TCTEncoder, TCTTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+
+    parser = HfArgumentParser((ModelArguments, DataArguments))
+    model_args, data_args = parser.parse_args_into_dataclasses()
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s-%(levelname)s-%(name)s- %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO
+    )
+
+    model_args: ModelArguments
+    data_args: DataArguments
+
+    logger.info("Model parameters %s", model_args)
+    logger.info("Data parameters %s", data_args)
+
+    # Set seed before initializing model.
+    set_seed(2022)   
+    
+    ### Only here is modified
+    tokenizer = TCTTokenizerFast.from_pretrained(
+        model_args.model_name_or_path, 
+    )
+    dense_encoder = TCTEncoder.from_pretrained(model_args.model_name_or_path)
+    config = dense_encoder.config
+    config.MCQ_M = model_args.MCQ_M
+    config.MCQ_K = model_args.MCQ_K
+    ### 
+
+    repconc = RepCONC(
+        config, 
+        dense_encoder, 
+        use_constraint=False, 
+        sk_epsilon=None, 
+        sk_iters=None)
+
+    corpus_embeds = np.load(data_args.input_corpus_embed_path)
+    repconc, index = warmup_from_embeds(
+        corpus_embeds,
+        repconc,
+    )
+    os.makedirs(data_args.output_model_dir, exist_ok=True)
+    repconc.save_pretrained(data_args.output_model_dir)
+    tokenizer.save_pretrained(data_args.output_model_dir)
+
+    os.makedirs(os.path.dirname(data_args.output_index_path), exist_ok=True)
+    os.makedirs(os.path.dirname(data_args.output_corpus_ids_path), exist_ok=True)
+    faiss.write_index(faiss.downcast_index(index.index), data_args.output_index_path)
+    corpus_ids = np.load(data_args.input_corpus_ids_path)
+    np.save(data_args.output_corpus_ids_path, corpus_ids)
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='repconc',
-    version='0.2.0',
+    version='0.2.1',
     packages=find_packages("src"),
     package_dir={'': 'src'},
     description='Learning Discrete Representations via Constrained Clustering for Effective and Efficient Dense Retrieval',

--- a/src/repconc/models/dense/evaluate_dense.py
+++ b/src/repconc/models/dense/evaluate_dense.py
@@ -54,7 +54,7 @@ def encode_dense_corpus(corpus: Dict[Union[str, int], str], model: Union[BertDen
         doc_out = DenseEvaluater(
             model=model,
             args=eval_args,
-            data_collator=get_collator_func(tokenizer, max_seq_length),
+            data_collator=get_collator_func(tokenizer, max_seq_length, input_text_type="doc"),
             tokenizer=tokenizer,
         ).predict(doc_dataset)
         if is_main_process(eval_args.local_rank):
@@ -73,7 +73,7 @@ def encode_dense_query(queries: Dict[Union[str, int], str], model: Union[BertDen
     query_out = DenseEvaluater(
         model=model,
         args=eval_args,
-        data_collator=get_collator_func(tokenizer, max_seq_length),
+        data_collator=get_collator_func(tokenizer, max_seq_length, input_text_type="query"),
         tokenizer=tokenizer,
     ).predict(query_dataset)
     query_embeds = query_out.predictions

--- a/src/repconc/models/repconc/evaluate_repconc.py
+++ b/src/repconc/models/repconc/evaluate_repconc.py
@@ -148,7 +148,7 @@ def encode_corpus(corpus: Dict[Union[str, int], str], model: RepCONC, tokenizer,
         output_format="code",
         model=model,
         args = eval_args,
-        data_collator=get_collator_func(tokenizer, max_seq_length),
+        data_collator=get_collator_func(tokenizer, max_seq_length, input_text_type="doc"),
         tokenizer=tokenizer,
     ).predict(corpus_dataset)
     corpus_codes = corpus_out.predictions
@@ -169,7 +169,7 @@ def encode_query(queries: Dict[int, str], model: RepCONC, tokenizer,
         output_format="continuous_embedding",
         model=model,
         args=eval_args,
-        data_collator=get_collator_func(tokenizer, max_seq_length),
+        data_collator=get_collator_func(tokenizer, max_seq_length, input_text_type="query"),
         tokenizer=tokenizer,
     ).predict(query_dataset)
     query_embeds = query_out.predictions


### PR DESCRIPTION
Some dense retrieval models use different tokenization methods for queries and documents, such as TCT-ColBERT. To support these models, repconc detects whether the tokenizer.__call__ has an argument named 'input_text_type'. If it has, the type will be set to 'query' or 'doc'. Therefore, the tokenizer can know whether the input is query or document and has customized behavior.